### PR TITLE
Update scripts to Python3

### DIFF
--- a/gca-cat
+++ b/gca-cat
@@ -34,4 +34,4 @@ if __name__ == '__main__':
     abstracts = [a for a in abstracts.values()]
 
     data = Abstract.to_json(abstracts)
-    sys.stdout.write(data.encode('utf-8'))
+    sys.stdout.write(data)

--- a/gca-doi
+++ b/gca-doi
@@ -19,7 +19,7 @@ def gen_dois(abstracts, prefix):
     for idx, a in enumerate(abstracts):
         a.doi = "%s%04d" % (prefix, idx+1)
     data = Abstract.to_json(abstracts)
-    sys.stdout.write(data.encode('utf-8'))
+    sys.stdout.write(data)
 
 
 def gen_xml_md_abstract_text(abstract, do_it=True):
@@ -89,7 +89,7 @@ def gen_xml(abstracts):
     docs = filter(lambda x: x is not None, docs)
     doc = E.resources(*docs)
     data = etree.tostring(doc, pretty_print=True)
-    sys.stdout.write(data.encode('utf-8'))
+    sys.stdout.write(data)
     print('%d of %d abstract\'s xml generated' % (len(docs), len(abstracts)), file=sys.stderr)
     diff = len(abstracts) - len(docs)
     if diff > 0:

--- a/gca-filter
+++ b/gca-filter
@@ -51,4 +51,4 @@ if __name__ == '__main__':
         abstracts = abstracts[:args.N]
 
     data = Abstract.to_json(abstracts)
-    sys.stdout.write(data.encode('utf-8'))
+    sys.stdout.write(data)

--- a/gca-select
+++ b/gca-select
@@ -42,8 +42,7 @@ if __name__ == '__main__':
         conf = Conference.from_data(fd.read())
 
     delimiter = '\n'
-
-    fields = [make_fields(field) for field in args.fields]
+    fields = args.fields
     fd = codecs.open(args.file, 'r', encoding='utf-8') if args.file != '-' else sys.stdin
     abstracts = Abstract.from_data(fd.read(), conf)
 
@@ -55,5 +54,5 @@ if __name__ == '__main__':
     val = do_chain(p_fld(do_chain(p_mlt(a.select_field(f)) for f in fields)) for a in abstracts)
     val = filter(lambda a: a is not None, val)
     data = delimiter.join(map(str, val))
-    sys.stdout.write(data.encode('utf-8'))
-    sys.stdout.write(delimiter.encode('utf-8'))
+    sys.stdout.write(data)
+    sys.stdout.write(delimiter)

--- a/gca-sort
+++ b/gca-sort
@@ -38,7 +38,7 @@ def get_sorter(field):
         reverse = False
         field = field[1:]
 
-    fields = make_fields(field)
+    fields = field
 
     def sort_fn(abstract):
         val = abstract.select_field(fields, fold=True)
@@ -77,4 +77,4 @@ if __name__ == '__main__':
         abstracts = [set_sort_id(a, idx, args.assign, args.altid) for idx, a in enumerate(abstracts)]
 
     data = Abstract.to_json(abstracts)
-    sys.stdout.write(data.encode('utf-8'))
+    sys.stdout.write(data)

--- a/gca-tex
+++ b/gca-tex
@@ -25,7 +25,7 @@ text_replacements = {
 
 def text_replace_all(text, replacements):
     if replacements is not None and text is not None:
-        for key, val in replacements.iteritems():
+        for key, val in replacements.items():
             text = text.replace(key, val)
 
     return text
@@ -79,4 +79,4 @@ if __name__ == '__main__':
                                    bare=args.bare, single_page=args.single_page,
                                    show_meta=args.show_meta)
     sys.stderr.write('[I] Done\n')
-    sys.stdout.write(rendered)
+    sys.stdout.write(rendered.decode('utf-8'))


### PR DESCRIPTION
Referring to the Issue #4 

Removed all the encoding to byte thing.

Also dealt with the fields in the gca-select and gca-sort. Those work well when there is single argument. For multiple arguments, I assumed they should be parsed in the '...' '...' format (e.g. 'title' 'topic').