### PR TITLE
Better latex template

### DIFF
--- a/gca-filter
+++ b/gca-filter
@@ -4,25 +4,31 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from gca.core import Abstract
+from gca.util import simplify_str
 
 import sys
 import argparse
 import codecs
 
 
-def make_filter(string):
+def make_filter(string, exact=False):
     x = string.split('=')
     assert(len(x) == 2)
     field = x[0].strip()
     fl = x[1].strip()
 
-    return lambda abstract: abstract.select_field(field, fold=True) == fl
+    if exact:
+        return lambda abstract: abstract.select_field(field, fold=True) == fl
+    else:
+        fl = simplify_str(fl)
+        return lambda abstract: simplify_str(abstract.select_field(field, fold=True)) == fl
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='GCA Filter - filter list of abstract by files')
     parser.add_argument('file', type=str, default='-')
     parser.add_argument('filter', type=str, nargs='+', help='filter to apply to each abstract')
+    parser.add_argument('-e', '--exact', default=False, action='store_true', help='Do use non-modified strings for comparisons. Default is to compare lower case and simplified strings.')
     parser.add_argument('--start-at', dest='P', default=None, type=int, help='start at abstract number')
     parser.add_argument('--max-num', dest='N', default=None, type=int, help='maximum number of abstracts to take')
     parser.add_argument('--or', dest='ft_or', default=False, action='store_true', help='use OR instead of AND')
@@ -32,7 +38,7 @@ if __name__ == '__main__':
     abstracts = Abstract.from_data(fd.read())
     fd.close()
 
-    filter_list = [make_filter(f) for f in args.filter]
+    filter_list = [make_filter(f, args.exact) for f in args.filter]
 
     if args.ft_or:
         result = []

--- a/gca-sort
+++ b/gca-sort
@@ -21,10 +21,17 @@ def sanitize_field(x):
     if type(x) == bytes:
         return x.strip()
     elif isinstance(x, string_types):
+        """ Why only the first character???
         if x[0] in s_conv:
             x = s_conv[x[0]] + x[1:]
-        return x.strip()
-
+        """
+        s = ''
+        for i in range(len(x)):
+            s += s_conv[x[i]] if x[i] in s_conv else x[i]
+        return s.strip()
+    elif isinstance(x, (tuple, list)):
+        x = [sanitize_field(xx) for xx in x]
+        print(x, file=sys.stderr)
     return x
 
 

--- a/gca-sort
+++ b/gca-sort
@@ -31,7 +31,6 @@ def sanitize_field(x):
         return s.strip()
     elif isinstance(x, (tuple, list)):
         x = [sanitize_field(xx) for xx in x]
-        print(x, file=sys.stderr)
     return x
 
 

--- a/gca-sort
+++ b/gca-sort
@@ -4,17 +4,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from gca.core import Abstract
-from gca.util import make_fields
-from six import string_types
+from gca.util import make_fields, simplify_str
 
 import argparse
 import codecs
 import sys
 
-
-s_from = u'aáàAâÂbBcCçÇdDeéEfFgGğĞhHiİîÎíīıIjJkKlLmMnNóoOöÖpPqQrRsSşŞtTuUûúÛüÜvVwWxXyYzZ'
-s_to   = u'aaaaaabbccccddeeeffgggghhiiiiiiiijjkkllmmnnoooooppqqrrssssttuuuuuuuvvwwxxyyzz'
-s_conv = dict(zip(s_from, s_to))
+from six import string_types
 
 
 def sanitize_field(x):
@@ -25,10 +21,7 @@ def sanitize_field(x):
         if x[0] in s_conv:
             x = s_conv[x[0]] + x[1:]
         """
-        s = ''
-        for i in range(len(x)):
-            s += s_conv[x[i]] if x[i] in s_conv else x[i]
-        return s.strip()
+        return simplify_str(x)
     elif isinstance(x, (tuple, list)):
         x = [sanitize_field(xx) for xx in x]
     return x

--- a/gca-tex
+++ b/gca-tex
@@ -70,7 +70,7 @@ if __name__ == '__main__':
     sys.stderr.write('[I] Pre-processing abstracts\n')
     txt = text_replace_all(txt, text_replacements['input'])
     data = json.loads(txt)
-    abstracts = [sanitize_abstract(Abstract(abstract, conference=conf), text_replacements) for abstract in data if abstract["abstrTypes"][0]["short"] == "poster"]  # this cannot be done with gca-filter!
+    abstracts = [sanitize_abstract(Abstract(abstract, conference=conf), text_replacements) for abstract in data]
     sys.stderr.write('[I] %d abstracts. Generating tex [figures: %s, conference: %s]\n' %
                      (len(abstracts), 'yes' if args.figures else 'NO', 'yes' if conf is not None else 'No'))
 

--- a/gca-tex
+++ b/gca-tex
@@ -70,7 +70,7 @@ if __name__ == '__main__':
     sys.stderr.write('[I] Pre-processing abstracts\n')
     txt = text_replace_all(txt, text_replacements['input'])
     data = json.loads(txt)
-    abstracts = [sanitize_abstract(Abstract(abstract, conference=conf), text_replacements) for abstract in data]
+    abstracts = [sanitize_abstract(Abstract(abstract, conference=conf), text_replacements) for abstract in data if abstract["abstrTypes"][0]["short"] == "talk"]  # this cannot be done with gca-filter!
     sys.stderr.write('[I] %d abstracts. Generating tex [figures: %s, conference: %s]\n' %
                      (len(abstracts), 'yes' if args.figures else 'NO', 'yes' if conf is not None else 'No'))
 

--- a/gca-tex
+++ b/gca-tex
@@ -70,7 +70,7 @@ if __name__ == '__main__':
     sys.stderr.write('[I] Pre-processing abstracts\n')
     txt = text_replace_all(txt, text_replacements['input'])
     data = json.loads(txt)
-    abstracts = [sanitize_abstract(Abstract(abstract, conference=conf), text_replacements) for abstract in data if abstract["abstrTypes"][0]["short"] == "talk"]  # this cannot be done with gca-filter!
+    abstracts = [sanitize_abstract(Abstract(abstract, conference=conf), text_replacements) for abstract in data if abstract["abstrTypes"][0]["short"] == "poster"]  # this cannot be done with gca-filter!
     sys.stderr.write('[I] %d abstracts. Generating tex [figures: %s, conference: %s]\n' %
                      (len(abstracts), 'yes' if args.figures else 'NO', 'yes' if conf is not None else 'No'))
 

--- a/gca/core.py
+++ b/gca/core.py
@@ -229,6 +229,20 @@ class Author(Entity):
         middle = d['middleName'] + u' ' if d['middleName'] else u""
         return d['firstName'] + u' ' + middle + d['lastName']
 
+    def latex_format_name(self, inverted=False):
+        d = self._data
+
+        if inverted:
+            middle = self.format_initials(d['middleName'], suffix='.')
+            if middle and len(middle):
+                middle = ' ' + middle
+            return u"\\lastname{%s}, \\firstname{%s%s}" % (d['lastName'], d['firstName'], middle)
+
+        first_middle = d['firstName']
+        if d['middleName']:
+            first_middle += u' ' + d['middleName']
+        return u"\\firstname{%s} \\lastname{%s}" % (first_middle, d['lastName'])
+
     def format_affiliation(self):
         af = self._data['affiliations']
         af_corrected = [str(x + 1) for x in sorted(af)]

--- a/gca/core.py
+++ b/gca/core.py
@@ -98,18 +98,18 @@ class Conference(Entity):
         gid = sort_id >> 16
         aid = sort_id & 0x0000FFFF
         groups = [Group(gd) for gd in self._data['groups']]
-        group = filter(lambda x: x.prefix == gid, groups)[0]
+        group = list(filter(lambda x: x.prefix == gid, groups))[0]
         return "%s %d" % (group.brief, aid)
 
     def get_group(self, sort_id):
         gid = sort_id >> 16
         groups = [Group(gd) for gd in self._data['groups']]
-        group = filter(lambda x: x.prefix == gid, groups)[0]
+        group = list(filter(lambda x: x.prefix == gid, groups))[0]
         return group
 
     def group_for_brief(self, brief):
         groups = [Group(gd) for gd in self._data['groups']]
-        selected = filter(lambda x: x.brief == brief, groups)
+        selected = list(filter(lambda x: x.brief == brief, groups))
         if len(selected) != 1:
             raise ValueError('Error finding group with brief [%s: %d]' % (brief, len(selected)))
         return selected[0]

--- a/gca/core.py
+++ b/gca/core.py
@@ -229,19 +229,19 @@ class Author(Entity):
         middle = d['middleName'] + u' ' if d['middleName'] else u""
         return d['firstName'] + u' ' + middle + d['lastName']
 
-    def latex_format_name(self, inverted=False):
+    def latex_format_name(self):
         d = self._data
-
-        if inverted:
-            middle = self.format_initials(d['middleName'], suffix='.')
-            if middle and len(middle):
-                middle = ' ' + middle
-            return u"\\authorname{\\lastname{%s}, \\firstname{%s%s}}" % (d['lastName'], d['firstName'], middle)
-
-        first_middle = d['firstName']
-        if d['middleName']:
-            first_middle += u' ' + d['middleName']
-        return u"\\authorname{\\firstname{%s} \\lastname{%s}}" % (first_middle, d['lastName'])
+        first = ''
+        shortfirst = ''
+        if d['firstName'] and len(d['firstName']):
+            first = d['firstName']
+            shortfirst = self.format_initials(d['firstName'], suffix='.')
+        middle = ''
+        shortmiddle = ''
+        if d['middleName'] and len(d['middleName']):
+            middle = u' ' + d['middleName']
+            shortmiddle = u' ' + self.format_initials(d['middleName'], suffix='.')
+        return u"\\authorname{%s}{%s}{%s}{%s}{%s}" % (first, middle, shortfirst, shortmiddle, d['lastName'])
 
     def format_affiliation(self):
         af = self._data['affiliations']

--- a/gca/core.py
+++ b/gca/core.py
@@ -236,12 +236,12 @@ class Author(Entity):
             middle = self.format_initials(d['middleName'], suffix='.')
             if middle and len(middle):
                 middle = ' ' + middle
-            return u"\\lastname{%s}, \\firstname{%s%s}" % (d['lastName'], d['firstName'], middle)
+            return u"\\authorname{\\lastname{%s}, \\firstname{%s%s}}" % (d['lastName'], d['firstName'], middle)
 
         first_middle = d['firstName']
         if d['middleName']:
             first_middle += u' ' + d['middleName']
-        return u"\\firstname{%s} \\lastname{%s}" % (first_middle, d['lastName'])
+        return u"\\authorname{\\firstname{%s} \\lastname{%s}}" % (first_middle, d['lastName'])
 
     def format_affiliation(self):
         af = self._data['affiliations']

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -49,50 +49,84 @@ import os
 
 \documentclass[a4paper,10pt,oneside]{book}
 
-\usepackage{ucs}
-\usepackage[utf8x]{inputenc}
-\usepackage[LGR, T1]{fontenc}
+%% math support:
+\usepackage{amsmath}    % needs to be included before the wasysym package
+\usepackage{mathtools}
+
+%% encoding and fonts:
+\usepackage[LGR,T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{newunicodechar}
+
 \usepackage{textcomp}
 \usepackage{textgreek}
-\usepackage{microtype}
-\DeclareUnicodeCharacter{8208}{-}
-\DeclareUnicodeCharacter{8210}{-}
-\DeclareUnicodeCharacter{8239}{ }
-\DeclareUnicodeCharacter{8288}{}
-\DeclareUnicodeCharacter{57404}{t}
-\DeclareUnicodeCharacter{700}{'}
-
-\usepackage[english]{babel}
-
-\usepackage{mathtools}
 \usepackage{amssymb}
+\usepackage{wasysym}
+\usepackage[squaren]{SIunits}
+
+\usepackage{microtype}
+
+%% add missing definitions of unicode characters:
+\newunicodechar{³}{^3}
+\newunicodechar{µ}{\micro}
+\newunicodechar{°}{\degree}
+\newunicodechar{♀}{\female}
+\newunicodechar{♂}{\male}
+\newunicodechar{´}{'}
+
+\DeclareUnicodeCharacter{8208}{-}    % HYPHEN
+\DeclareUnicodeCharacter{8210}{-}    % DASH
+\DeclareUnicodeCharacter{8239}{\,}   % NARROW SPACE
+\DeclareUnicodeCharacter{8288}{}
+%%\DeclareUnicodeCharacter{700}{'}
+%%\usepackage{tipa}
+%%\DeclareUnicodeCharacter{57404}{\textiota}
+
+%% language:
+\usepackage[english]{babel}
 
 %%\usepackage{chapterthumb}
 
+%% graphics and figures:
+\usepackage{xcolor}
 % if figures is not None:
-\usepackage{caption}
 \usepackage{graphicx}
 \graphicspath{ {${figures}/} }
+\usepackage[format=plain,singlelinecheck=off,labelfont=bf,font={small,sf}]{caption}
 %endif
 
 \usepackage[top=20mm, bottom=20mm, left=20mm, right=20mm]{geometry}
 \setcounter{secnumdepth}{-1}
 
-\usepackage{xcolor}
 \usepackage[breaklinks=true,colorlinks=true,citecolor=blue!30!black,urlcolor=blue!30!black,linkcolor=blue!30!black]{hyperref}
 
 \usepackage{multind}
 \makeindex{pages}
 \makeindex{posterid}
 
-\newenvironment{abstractblock}{\newpage\noindent\begin{minipage}[t]{1.\textwidth}}{\end{minipage}\vskip \glueexpr\smallskipamount + 0pt plus 10ex minus 3ex\relax
-    \pagebreak[3]}
+%% environment for formatting the whole abstract:
+\newenvironment{abstractblock}{}{\newpage}
+
+%% environment for formatting the authors block:
 \newenvironment{authors}{}{}
+
+%% environment for formatting the affiliations:
 \newenvironment{affiliations}{\footnotesize\itshape\begin{enumerate}}{\end{enumerate}}
-\newenvironment{abstracttext}{}{}
+
+%% environment for formatting the figure block:
+\newenvironment{afigure}{\begin{center}\begin{minipage}{0.9\textwidth}}{\end{minipage}\end{center}}
+%% the maximum height of a figure:
+\newlength{\figureheight}
+\setlength{\figureheight}{0.35\textheight}
+
+%% environment for formatting the acknowledgements block:
 \newenvironment{acknowledgements}{\small}{}
-\newenvironment{references}{\footnotesize\begin{list}{}{\leftmargin=1.5em \listparindent=0pt \rightmargin=0pt \topsep=0.5ex \parskip=0pt \partopsep=0pt \itemsep=0pt \parsep=0pt}
-}{\end{list}}
+
+%% environment for formatting the references:
+\newenvironment{references}%
+  {\footnotesize\begin{list}{}{\leftmargin=1.5em \listparindent=0pt \rightmargin=0pt \topsep=0.5ex \parskip=0pt \partopsep=0pt \itemsep=0pt \parsep=0pt}}%
+  {\end{list}}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{document}
@@ -150,9 +184,8 @@ ${mk_affiliations(abstract.affiliations)}
 doi: \href{http://dx.doi.org/${abstract.doi}}{${abstract.doi}}
 %endif
 
-\begin{abstracttext}
 ${abstract.text}
-\end{abstracttext}
+
 %if abstract.alt_id > 0 and abstract.conference is not None:
   \textbf{See also Poster}: ${abstract.conference.sort_id_to_string(abstract.alt_id)}
 %endif
@@ -213,13 +246,10 @@ ${mk_tex_text(acknowledgements)}
 </%def>
 
 <%def name="mk_figure(figure)">
-\vspace{1mm}\makebox[\textwidth][c]{\begin{minipage}[c]{0.9\linewidth}
-    \centering
-    \includegraphics[width=0.50\textwidth]{${figure.uuid}}
+\begin{afigure}
+    \centerline{\includegraphics[width=1\linewidth, height=1\figureheight, keepaspectratio]{${figure.uuid}}}
     \captionof*{figure}{\small ${mk_tex_text(figure.caption)}}
-\end{minipage}
-\vspace{1em}
-}
+\end{afigure}
 </%def>
 
 <%def name="mk_doi(ref)">

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -180,11 +180,11 @@ import os
 \setlength{\figureheight}{0.35\textheight}
 
 %% environment for formatting the acknowledgements block:
-\newenvironment{acknowledgements}{\small}{}
+\newenvironment{acknowledgements}{\subsubsection{Acknowledgements}\small}{}
 
 %% environment for formatting the references:
 \newenvironment{references}%
-  {\footnotesize\begin{list}{}{\leftmargin=1.5em \listparindent=0pt \rightmargin=0pt \topsep=0.5ex \parskip=0pt \partopsep=0pt \itemsep=0pt \parsep=0pt}}%
+  {\subsubsection{References}\footnotesize\begin{list}{}{\leftmargin=1.5em \listparindent=0pt \rightmargin=0pt \topsep=0.5ex \parskip=0pt \partopsep=0pt \itemsep=0pt \parsep=0pt}}%
   {\end{list}}
 
 
@@ -291,14 +291,12 @@ Talk: ${mk_tex_text(abstract.reason_for_talk)}\\*[-0.5ex]
 </%def>
 
 <%def name="mk_acknowledgements(acknowledgements)">
-\subsubsection{Acknowledgements}
 \begin{acknowledgements}
 ${mk_tex_text(acknowledgements)}
 \end{acknowledgements}
 </%def>
 
 <%def name="mk_references(references)">
-\subsubsection{References}
 \begin{references}
 %for idx, ref in enumerate(references):
   \item[${idx+1}] ${mk_tex_text(ref.display_text)} ${mk_doi(ref)}

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -47,20 +47,12 @@ import os
 
 %if not bare:
 
-%%!TEX TS-program = lualatex
-%%!TEX encoding = UTF-8 Unicode
-
-\documentclass[%%
-a5paper,
-9pt,%%
-twoside,%%
-final%%
-]{scrbook}
+\documentclass[a4paper,10pt,oneside]{book}
 
 \usepackage{ucs}
-\usepackage[greek, french, spanish, english]{babel}
 \usepackage[utf8x]{inputenc}
 \usepackage[LGR, T1]{fontenc}
+\usepackage[english]{babel}
 \usepackage{textcomp}
 \usepackage{textgreek}
 \usepackage{microtype}
@@ -74,7 +66,7 @@ final%%
 \usepackage{mathtools}
 \usepackage{amssymb}
 
-\usepackage{chapterthumb}
+%%\usepackage{chapterthumb}
 
 % if figures is not None:
 \usepackage{caption}
@@ -82,32 +74,26 @@ final%%
 \graphicspath{ {${figures}/} }
 %endif
 
-\usepackage{needspace}
+\usepackage[top=20mm, bottom=20mm, left=20mm, right=20mm]{geometry}
+\setcounter{secnumdepth}{-1}
 
-\parskip0.5ex
-
-\setlength{\parindent}{0in}
-
-\setlength{\topmargin}{-23mm}
-\setlength{\oddsidemargin}{-8mm}
-\setlength{\evensidemargin}{-12mm}
-\setlength{\textwidth}{117mm}
-\setlength{\textheight}{185mm}
-\setlength{\footskip}{20pt}
-
-\usepackage{hyperref}
+\usepackage{xcolor}
+\usepackage[breaklinks=true,colorlinks=true,citecolor=blue!30!black,urlcolor=blue!30!black,linkcolor=blue!30!black]{hyperref}
 
 \usepackage{multind}
 \makeindex{pages}
 \makeindex{posterid}
 
+\newenvironment{abstractblock}{\newpage\noindent\begin{minipage}[t]{1.\textwidth}}{\end{minipage}\vspace{2ex}}
+\newenvironment{authors}{}{}
+\newenvironment{affiliations}{\footnotesize\itshape\begin{enumerate}}{\end{enumerate}}
+\newenvironment{abstracttext}{}{}
+\newenvironment{acknowledgements}{\small}{}
+\newenvironment{references}{\footnotesize\begin{list}{}{\leftmargin=1.5em \listparindent=0pt \rightmargin=0pt \topsep=0.5ex \parskip=0pt \partopsep=0pt \itemsep=0pt \parsep=0pt}
+}{\end{list}}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{document}
-
-\frontmatter
-
-%%%%%%%%%%%%%
-\mainmatter
 
 %endif
 
@@ -123,10 +109,10 @@ cur_state = check_cur_state(None, None)
     new_chapter, new_section = check_cur_state(abstract, cur_state)
 %>
     %if new_chapter is not None:
-    \cleardoublepage \chapter{${new_chapter}} \addtocounter{chapterthumb}{1} \newpage
+    %%\cleardoublepage \chapter{${new_chapter}} \addtocounter{chapterthumb}{1} \newpage
     %endif
     %if new_section is not None:
-    \section*{${new_section}}
+    \section{${new_section}}
     %endif
 
     ${mk_abstract(idx, abstract, figures is not None, show_meta)}
@@ -149,74 +135,72 @@ cur_state = check_cur_state(None, None)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 <%def name="mk_abstract(idx, abstract, include_figures, print_meta)">
-    \subsection*{\textmd{\sffamily [${abstract.poster_id}]} \hspace{1mm} ${mk_tex_text(abstract.title)} }
-    \noindent ${mk_authors(abstract.authors)} \\*[0.5ex]
-    \small ${mk_affiliations(abstract.affiliations)} \
-    %if abstract.doi:
-    doi: \href{http://dx.doi.org/${abstract.doi}}{${abstract.doi}}
-    %endif
-    \normalsize \nopagebreak\\*[-2.0ex]
+\begin{abstractblock}
+\section[${abstract.poster_id}]{${mk_tex_text(abstract.title)}}
+${mk_authors(abstract.authors)}
+${mk_affiliations(abstract.affiliations)}
+%if abstract.doi:
+doi: \href{http://dx.doi.org/${abstract.doi}}{${abstract.doi}}
+%endif
 
+\begin{abstracttext}
+${abstract.text}
+\end{abstracttext}
 
-    ${abstract.text}
-    %if abstract.alt_id > 0 and abstract.conference is not None:
-
-
-        \textbf{See also Poster}: ${abstract.conference.sort_id_to_string(abstract.alt_id)}
-    %endif
-    %if len(abstract.figures) and include_figures:
-        ${mk_figure(abstract.figures[0])}
-    %endif
-    %if abstract.acknowledgements:
-        ${mk_acknowledgements(abstract.acknowledgements)}
-    %endif
-    %if abstract.references:
-        ${mk_references(abstract.references)}
-    %endif
-    %if print_meta:
-    \small
-    Topic: ${abstract.topic}
-    %if abstract.is_talk:
-    Talk: ${mk_tex_text(abstract.reason_for_talk)}\\*[-0.5ex]
-    %endif
-    \normalsize
-    %endif
-    \vskip \glueexpr\smallskipamount + 0pt plus 10ex minus 3ex\relax
-    \pagebreak[3]
-
+%if len(abstract.figures) and include_figures:
+    ${mk_figure(abstract.figures[0])}
+%endif
+%if abstract.acknowledgements:
+    ${mk_acknowledgements(abstract.acknowledgements)}
+%endif
+%if abstract.references:
+    ${mk_references(abstract.references)}
+%endif
+%if print_meta:
+\small
+Topic: ${abstract.topic}
+%if abstract.is_talk:
+Talk: ${mk_tex_text(abstract.reason_for_talk)}\\*[-0.5ex]
+%endif
+\normalsize
+%endif
+\end{abstractblock}
 </%def>
 
 <%def name="mk_authors(authors)">
+\begin{authors}
 % for idx, author in enumerate(authors):
   <%
      sep = ', ' if idx+1 < len(authors) else ''
      aff = author.format_affiliation()
      epi = '$^{%s}$' % aff if aff else ''
-  %> ${author.format_name()}${epi}${sep}\index{pages}{${author.index_name}} \
+  %> ${author.format_name()}${epi}${sep}\index{pages}{${author.index_name}}
 % endfor
+\end{authors}
 </%def>
 
 <%def name="mk_affiliations(affiliations)">
+\begin{affiliations}
 % for idx, affiliation in enumerate(affiliations):
-  \emph{${idx+1}. ${mk_tex_text(affiliation.format_affiliation())}}\\*[-0.5ex]
+  \item[${idx+1}.] ${mk_tex_text(affiliation.format_affiliation())}
 % endfor
+\end{affiliations}
 </%def>
 
 <%def name="mk_acknowledgements(acknowledgements)">
-\vspace{1ex}\renewcommand{\baselinestretch}{0.9}\footnotesize \textbf{Acknowledgements} \\*[0em]
-${mk_tex_text(acknowledgements)}\
-\par\renewcommand{\baselinestretch}{1.0}\normalsize
+\subsubsection{Acknowledgements}
+\begin{acknowledgements}
+${mk_tex_text(acknowledgements)}
+\end{acknowledgements}
 </%def>
 
 <%def name="mk_references(references)">
-\vspace{1ex}
-\renewcommand{\baselinestretch}{0.9}\footnotesize \needspace{3\baselineskip}\textbf{References}\nopagebreak
-\begin{list}{}{\leftmargin=1.5em \listparindent=0pt \rightmargin=0pt \topsep=0.5ex \parskip=0pt \partopsep=0pt \itemsep=0pt \parsep=0pt}
+\subsubsection{References}
+\begin{references}
 %for idx, ref in enumerate(references):
   \item[${idx+1}] ${mk_tex_text(ref.display_text)} ${mk_doi(ref)}
 %endfor
-\end{list}
-\par\renewcommand{\baselinestretch}{1.0}\normalsize
+\end{references}
 </%def>
 
 <%def name="mk_figure(figure)">

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -157,10 +157,8 @@ import os
 %else:
 \newcommand{\newabstract}{}
 %endif
-%% Command for setting the abstract's title. First argument is some optional string, second is poster ID, third is the title
-\newcommand{\abstractsection}[3][]{\section[#2]{#3}}
-%% Command for making a list of abstracts with the name of the first author and the title.
-\newcommand{\abstractinfo}[2]{}
+%% Command for setting the abstract's title. First argument is some optional string, second is poster ID, third is last name of first author, fourth is title of abstract
+\newcommand{\abstractsection}[4][]{\section[#3: #4]{#4}}
 
 %% environment for formatting the authors block:
 \newenvironment{authors}{\begin{flushleft}\setstretch{1.2}\sffamily}{\end{flushleft}\vspace{-3ex}}
@@ -235,8 +233,7 @@ cur_state = check_cur_state(None, None)
 
 <%def name="mk_abstract(idx, abstract, include_figures, print_meta)">
 \begin{abstractblock}
-\abstractsection[Gwinner]{${abstract.poster_id}}{${mk_tex_text(abstract.title)}}
-\abstractinfo{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title)}}
+\abstractsection[Gwinner]{${abstract.poster_id}}{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title)}}
 ${mk_authors(abstract.authors)}
 ${mk_affiliations(abstract.affiliations)}
 %if abstract.doi:

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -142,8 +142,7 @@ import os
 
 \usepackage[sf,bf]{titlesec}
 \setcounter{secnumdepth}{1}
-\newcommand{\gwinner}{}
-\titleformat{\section}{\sffamily\Large\bfseries}{}{0em}{\marginnote{\huge P\arabic{section}\\[-1.7ex]{\normalfont\sffamily\tiny \gwinner}}[-2.4ex]}
+\titleformat{\section}{\sffamily\Large\bfseries}{}{0em}{\marginnote{\huge P\arabic{section}}[-2.4ex]}
 
 \usepackage{imakeidx}
 \makeindex[name=authors, title={Author index}]
@@ -152,15 +151,22 @@ import os
 
 %% environment for formatting the whole abstract:
 \newenvironment{abstractblock}{}{}
-\newcommand{\abstractsection}[3][]{\renewcommand{\gwinner}{#1}\section[#2]{#3}}
+%if single_page:
+\newcommand{\newabstract}{\clearpage}
+%else:
+\newcommand{\newabstract}{}
+%endif
+\newcommand{\newabstract}{}
+\newcommand{\abstractsection}[3][]{\section[#2]{#3}}
 
 %% environment for formatting the authors block:
-\newenvironment{authors}{\begin{sffamily}}{\end{sffamily}}
+\newenvironment{authors}{\begin{flushleft}\setstretch{1.2}\sffamily}{\end{flushleft}\vspace{-3ex}}
+\newcommand{\authorname}[1]{\mbox{#1}}
 \newcommand{\firstname}[1]{#1}
 \newcommand{\lastname}[1]{\textbf{#1}}
 
 %% environment for formatting the affiliations:
-\newenvironment{affiliations}{\footnotesize\sffamily\begin{enumerate}}{\end{enumerate}}
+\newenvironment{affiliations}{\begin{flushleft}\begin{enumerate}\setlength{\itemsep}{-0.5ex}\footnotesize\sffamily}{\end{enumerate}\end{flushleft}}
 
 %% environment for formatting the abstract main text:
 \newenvironment{abstracttext}{\noindent\hspace*{-0.8ex}}{}
@@ -209,9 +215,6 @@ cur_state = check_cur_state(None, None)
     %endif
 
     ${mk_abstract(idx, abstract, figures is not None, show_meta)}
-    %if single_page:
-    \clearpage
-    %endif
 % endfor
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -261,6 +264,7 @@ Talk: ${mk_tex_text(abstract.reason_for_talk)}\\*[-0.5ex]
 \normalsize
 %endif
 \end{abstractblock}
+\newabstract
 </%def>
 
 <%def name="mk_authors(authors)">

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -67,7 +67,7 @@ import os
 \usepackage{microtype}
 
 %% add missing definitions of unicode characters:
-\newunicodechar{³}{^3}
+\newunicodechar{³}{$^3$}
 \newunicodechar{µ}{\micro}
 \newunicodechar{°}{\degree}
 \newunicodechar{♀}{\female}
@@ -151,13 +151,16 @@ import os
 
 %% environment for formatting the whole abstract:
 \newenvironment{abstractblock}{}{}
+%% a command for separating subsequent abstracts:
 %if single_page:
 \newcommand{\newabstract}{\clearpage}
 %else:
 \newcommand{\newabstract}{}
 %endif
-\newcommand{\newabstract}{}
+%% Command for setting the abstract's title. First argument is some optional string, second is poster ID, third is the title
 \newcommand{\abstractsection}[3][]{\section[#2]{#3}}
+%% Command for making a list of abstracts with the name of the first author and the title.
+\newcommand{\abstractinfo}[2]{}
 
 %% environment for formatting the authors block:
 \newenvironment{authors}{\begin{flushleft}\setstretch{1.2}\sffamily}{\end{flushleft}\vspace{-3ex}}
@@ -233,6 +236,7 @@ cur_state = check_cur_state(None, None)
 <%def name="mk_abstract(idx, abstract, include_figures, print_meta)">
 \begin{abstractblock}
 \abstractsection[Gwinner]{${abstract.poster_id}}{${mk_tex_text(abstract.title)}}
+\abstractinfo{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title)}}
 ${mk_authors(abstract.authors)}
 ${mk_affiliations(abstract.affiliations)}
 %if abstract.doi:

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -47,7 +47,7 @@ import os
 
 %if not bare:
 
-\documentclass[a4paper,10pt,oneside]{book}
+\documentclass[a4paper,11pt,oneside]{book}
 
 %% math support:
 \usepackage{amsmath}    % needs to be included before the wasysym package
@@ -80,6 +80,12 @@ import os
 \DeclareUnicodeCharacter{8239}{\,}   % NARROW SPACE
 \DeclareUnicodeCharacter{8288}{}
 %%\DeclareUnicodeCharacter{700}{'}
+\DeclareUnicodeCharacter{FB00}{ff}
+\DeclareUnicodeCharacter{FB01}{fi}
+\DeclareUnicodeCharacter{FB02}{fl}
+\DeclareUnicodeCharacter{FB03}{ffi}
+\DeclareUnicodeCharacter{FB04}{ffl}
+\DeclareUnicodeCharacter{FB05}{ft}
 %%\usepackage{tipa}
 %%\DeclareUnicodeCharacter{57404}{\textiota}
 
@@ -90,28 +96,71 @@ import os
 
 %% graphics and figures:
 \usepackage{xcolor}
+
+%% UT primary colors:
+\definecolor{red}{RGB}{165,30,55}
+\definecolor{gray}{RGB}{50,65,75}
+\definecolor{gold}{RGB}{180,160,105}
+
+%% UT secondary colors:
+\definecolor{darkblue}{RGB}{65,90,140}
+\definecolor{blue}{RGB}{0,105,170}
+\definecolor{lightblue}{RGB}{80,170,200}
+\definecolor{turquoise}{RGB}{130,185,160}
+\definecolor{lightgreen}{RGB}{125,165,75}
+\definecolor{green}{RGB}{50,110,30}
+\definecolor{lightred}{RGB}{200,80,60}
+\definecolor{purple}{RGB}{175,110,150}
+\definecolor{lightpurple}{RGB}{180,160,150}
+\definecolor{lightbrown}{RGB}{215,180,105}
+\definecolor{orange}{RGB}{210,150,0}
+\definecolor{brown}{RGB}{145,105,70}
+
 % if figures is not None:
 \usepackage{graphicx}
 \graphicspath{ {${figures}/} }
 \usepackage[format=plain,singlelinecheck=off,labelfont=bf,font={small,sf}]{caption}
 %endif
 
-\usepackage[top=20mm, bottom=20mm, left=20mm, right=20mm]{geometry}
-\setcounter{secnumdepth}{-1}
+%% layout:
+\usepackage[top=20mm, bottom=20mm, left=23mm, right=23mm, headsep=9mm, marginparsep=5mm]{geometry}
 
-\usepackage[breaklinks=true,colorlinks=true,citecolor=blue!30!black,urlcolor=blue!30!black,linkcolor=blue!30!black]{hyperref}
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\fancyhf{}
+\setlength{\fboxsep}{0pt}
+\setlength{\unitlength}{1mm}
+\newcommand{\headertext}{Poster}
+\newcommand{\headercolor}{green}
+\fancyhead[RO]{\begin{picture}(0,0)\put(0,3){\colorbox{\headercolor}{\makebox[23mm][c]{\sffamily\Large \rule[-1.5ex]{0pt}{5ex}\textcolor{white}{\headertext}}}}\end{picture}}
+\fancyhead[LE]{\begin{picture}(0,0)\put(-23,3){\colorbox{\headercolor}{\makebox[23mm][c]{\sffamily\Large \rule[-1.5ex]{0pt}{5ex}\textcolor{white}{\headertext}}}}\end{picture}}
+\fancyhead[LO,RE]{15. Annual Meeting of the Ethological Society, T\"ubingen, 2020}
+\fancyfoot[LE,RO]{\thepage}
+\renewcommand{\headrulewidth}{0pt}
+
+\usepackage{marginnote}
+
+\usepackage[sf,bf]{titlesec}
+\setcounter{secnumdepth}{1}
+\newcommand{\gwinner}{}
+\titleformat{\section}{\sffamily\Large\bfseries}{}{0em}{\marginnote{\huge P\arabic{section}\\[-1.7ex]{\normalfont\sffamily\tiny \gwinner}}[-2.4ex]}
 
 \usepackage{imakeidx}
 \makeindex[name=authors, title={Author index}]
 
+\usepackage[breaklinks=true,colorlinks=true,citecolor=blue!30!black,urlcolor=blue!30!black,linkcolor=blue!30!black]{hyperref}
+
 %% environment for formatting the whole abstract:
-\newenvironment{abstractblock}{}{\newpage}
+\newenvironment{abstractblock}{}{}
+\newcommand{\abstractsection}[3][]{\renewcommand{\gwinner}{#1}\section[#2]{#3}}
 
 %% environment for formatting the authors block:
-\newenvironment{authors}{}{}
+\newenvironment{authors}{\begin{sffamily}}{\end{sffamily}}
+\newcommand{\firstname}[1]{#1}
+\newcommand{\lastname}[1]{\textbf{#1}}
 
 %% environment for formatting the affiliations:
-\newenvironment{affiliations}{\footnotesize\itshape\begin{enumerate}}{\end{enumerate}}
+\newenvironment{affiliations}{\footnotesize\sffamily\begin{enumerate}}{\end{enumerate}}
 
 %% environment for formatting the abstract main text:
 \newenvironment{abstracttext}{\noindent\hspace*{-0.8ex}}{}
@@ -168,6 +217,8 @@ cur_state = check_cur_state(None, None)
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% appendix
 %if not bare:
+\renewcommand{\headertext}{Index}
+\renewcommand{\headercolor}{white}
 \backmatter
 
 \printindex[authors]
@@ -178,7 +229,7 @@ cur_state = check_cur_state(None, None)
 
 <%def name="mk_abstract(idx, abstract, include_figures, print_meta)">
 \begin{abstractblock}
-\subsection[${abstract.poster_id}]{${mk_tex_text(abstract.title)}}
+\abstractsection[Gwinner]{${abstract.poster_id}}{${mk_tex_text(abstract.title)}}
 ${mk_authors(abstract.authors)}
 ${mk_affiliations(abstract.affiliations)}
 %if abstract.doi:
@@ -219,7 +270,7 @@ Talk: ${mk_tex_text(abstract.reason_for_talk)}\\*[-0.5ex]
      sep = ', ' if idx+1 < len(authors) else ''
      aff = author.format_affiliation()
      epi = '$^{%s}$' % aff if aff else ''
-  %> ${author.format_name()}${epi}${sep}\index[authors]{${author.index_name}}
+  %> ${author.latex_format_name()}${epi}${sep}\index[authors]{${author.index_name}}
 % endfor
 \end{authors}
 </%def>

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -73,6 +73,7 @@ import os
 \newunicodechar{♀}{\female}
 \newunicodechar{♂}{\male}
 \newunicodechar{´}{'}
+\newunicodechar{−}{\text{--}}
 
 \DeclareUnicodeCharacter{8208}{-}    % HYPHEN
 \DeclareUnicodeCharacter{8210}{-}    % DASH
@@ -137,8 +138,6 @@ import os
 
 %%%%%%%%%%%%%
 \mainmatter
-
-\chapter{Etho 2020 --- Poster}
 
 %endif
 

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -158,13 +158,14 @@ import os
 \newcommand{\newabstract}{}
 %endif
 %% Command for setting the abstract's title. First argument is some optional string, second is poster ID, third is last name of first author, fourth is title of abstract
-\newcommand{\abstractsection}[4][]{\section[#3: #4]{#4}}
+\newcommand{\abstracttitle}[4][]{\section[#3: #4]{#4}}
 
 %% environment for formatting the authors block:
 \newenvironment{authors}{\begin{flushleft}\setstretch{1.2}\sffamily}{\end{flushleft}\vspace{-3ex}}
-\newcommand{\authorname}[1]{\mbox{#1}}
-\newcommand{\firstname}[1]{#1}
-\newcommand{\lastname}[1]{\textbf{#1}}
+%% formatting of author names (first, middle, first initial, middle initial, last name):
+\newcommand{\authorname}[5]{\mbox{#1#2 \textbf{#5}}}  %% first and middle name plus bold last name
+%% \newcommand{\authorname}[5]{\mbox{\textbf{#5}, #3#4}}  %% bold last name, first and middle initials
+%% \newcommand{\authorname}[5]{\mbox{\textbf{#5}, #1#4}}  %% bold last name, full first name and middle initials
 
 %% environment for formatting the affiliations:
 \newenvironment{affiliations}{\begin{flushleft}\begin{enumerate}\setlength{\itemsep}{-0.5ex}\footnotesize\sffamily}{\end{enumerate}\end{flushleft}}
@@ -233,7 +234,7 @@ cur_state = check_cur_state(None, None)
 
 <%def name="mk_abstract(idx, abstract, include_figures, print_meta)">
 \begin{abstractblock}
-\abstractsection[Gwinner]{${abstract.poster_id}}{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title)}}
+\abstracttitle[Gwinner]{${abstract.poster_id}}{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title)}}
 ${mk_authors(abstract.authors)}
 ${mk_affiliations(abstract.affiliations)}
 %if abstract.doi:
@@ -265,6 +266,7 @@ Talk: ${mk_tex_text(abstract.reason_for_talk)}\\*[-0.5ex]
 \normalsize
 %endif
 \end{abstractblock}
+
 \newabstract
 </%def>
 

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -49,6 +49,9 @@ import os
 
 \documentclass[a4paper,11pt,oneside]{book}
 
+%% customize the abstracts using the environments and commands
+%% provided at the end of the header!
+
 %% math support:
 \usepackage{amsmath}    % needs to be included before the wasysym package
 \usepackage{mathtools}
@@ -89,33 +92,13 @@ import os
 %%\usepackage{tipa}
 %%\DeclareUnicodeCharacter{57404}{\textiota}
 
+%%%%% basic layout %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 %% language:
 \usepackage[english]{babel}
 
-%%\usepackage{chapterthumb}
-
 %% graphics and figures:
 \usepackage{xcolor}
-
-%% UT primary colors:
-\definecolor{red}{RGB}{165,30,55}
-\definecolor{gray}{RGB}{50,65,75}
-\definecolor{gold}{RGB}{180,160,105}
-
-%% UT secondary colors:
-\definecolor{darkblue}{RGB}{65,90,140}
-\definecolor{blue}{RGB}{0,105,170}
-\definecolor{lightblue}{RGB}{80,170,200}
-\definecolor{turquoise}{RGB}{130,185,160}
-\definecolor{lightgreen}{RGB}{125,165,75}
-\definecolor{green}{RGB}{50,110,30}
-\definecolor{lightred}{RGB}{200,80,60}
-\definecolor{purple}{RGB}{175,110,150}
-\definecolor{lightpurple}{RGB}{180,160,150}
-\definecolor{lightbrown}{RGB}{215,180,105}
-\definecolor{orange}{RGB}{210,150,0}
-\definecolor{brown}{RGB}{145,105,70}
-
 % if figures is not None:
 \usepackage{graphicx}
 \graphicspath{ {${figures}/} }
@@ -123,84 +106,117 @@ import os
 %endif
 
 %% layout:
-\usepackage[top=20mm, bottom=20mm, left=23mm, right=23mm, headsep=9mm, marginparsep=5mm]{geometry}
+\usepackage[top=20mm, bottom=20mm, left=23mm, right=23mm]{geometry}
 
+\usepackage{setspace}
+
+%% customize header and footer:
+%% (you may want to add the conference title, the abstract number, etc.)
 \usepackage{fancyhdr}
 \pagestyle{fancy}
 \fancyhf{}
-\setlength{\fboxsep}{0pt}
-\setlength{\unitlength}{1mm}
-\newcommand{\headertext}{Poster}
-\newcommand{\headercolor}{green}
-\fancyhead[RO]{\begin{picture}(0,0)\put(0,3){\colorbox{\headercolor}{\makebox[23mm][c]{\sffamily\Large \rule[-1.5ex]{0pt}{5ex}\textcolor{white}{\headertext}}}}\end{picture}}
-\fancyhead[LE]{\begin{picture}(0,0)\put(-23,3){\colorbox{\headercolor}{\makebox[23mm][c]{\sffamily\Large \rule[-1.5ex]{0pt}{5ex}\textcolor{white}{\headertext}}}}\end{picture}}
-\fancyhead[LO,RE]{15. Annual Meeting of the Ethological Society, T\"ubingen, 2020}
-\fancyfoot[LE,RO]{\thepage}
+\fancyhead[LE,RO]{\thepage}
 \renewcommand{\headrulewidth}{0pt}
 
-\usepackage{marginnote}
-
+%% customize chapter and sections appearance:
+%% use commands of the titlesec package to modify the layout of the abstract's title:
 \usepackage[sf,bf]{titlesec}
-\setcounter{secnumdepth}{1}
-\titleformat{\section}{\sffamily\Large\bfseries}{}{0em}{\marginnote{\huge P\arabic{section}}[-2.4ex]}
+\titleformat{\section}{\sffamily\bfseries\Large\raggedright}{\thesection}{1em}{}
 
+%% number the abstracts, but do not number acknowledgements and references:
+\setcounter{secnumdepth}{1}
+%% abstract number without chapter number:
+\renewcommand{\thesection}{\arabic{section}}
+%%\renewcommand{\thesection}{P\arabic{section}}  % indicate poster
+
+%% generate author index:
 \usepackage{imakeidx}
 \makeindex[name=authors, title={Author index}]
 
+%% make nice clickable links:
 \usepackage[breaklinks=true,colorlinks=true,citecolor=blue!30!black,urlcolor=blue!30!black,linkcolor=blue!30!black]{hyperref}
 
-%% environment for formatting the whole abstract:
-\newenvironment{abstractblock}{}{}
-%% a command for separating subsequent abstracts:
+%%%%% abstract specific layout %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Each element of the abstract (title, authors, affiliations, text, ... is encapsulated
+%% in an environment or command as defined in the following.
+%% Change their definition to modify the appaerance of the abstracts.
+
+%% Environment for formatting the whole abstract:
+\newenvironment{abstractblock}
+  {}
+  {}
+
+%% Command for separating subsequent abstracts:
 %if single_page:
 \newcommand{\newabstract}{\clearpage}
 %else:
 \newcommand{\newabstract}{}
 %endif
-%% Command for setting the abstract's title. First argument is some optional string, second is poster ID, third is last name of first author, fourth is title of abstract
-\newcommand{\abstracttitle}[4][]{\section[#3: #4]{#4}}
 
-%% environment for formatting the authors block:
-\newenvironment{authors}{\begin{flushleft}\setstretch{1.2}\sffamily}{\end{flushleft}\vspace{-3ex}}
-%% formatting of author names (first, middle, first initial, middle initial, last name):
+%% Command for setting the abstract's title. It gets four arguments:
+%% 1. some optional string (user supplied by manual editing the latex file)
+%% 2. poster ID
+%% 3. last name of first author
+%% 4. title of abstract
+\newcommand{\abstracttitle}[4][]{\section[#3: #4]{#4}}
+%%\newcommand{\abstracttitle}[4][]{\section[#2]{#4}}
+
+%% Environment for formatting the authors block:
+\newenvironment{authors}
+  {\begin{flushleft}\setstretch{1.2}\sffamily}
+  {\end{flushleft}\vspace{-3ex}}
+
+%% Command for formatting of author names. Five arguments:
+%% 1. first name
+%% 2. middle name
+%% 3. initial of first name
+%% 4. initial of middle name
+%% 5. last name
 \newcommand{\authorname}[5]{\mbox{#1#2 \textbf{#5}}}  %% first and middle name plus bold last name
 %% \newcommand{\authorname}[5]{\mbox{\textbf{#5}, #3#4}}  %% bold last name, first and middle initials
 %% \newcommand{\authorname}[5]{\mbox{\textbf{#5}, #1#4}}  %% bold last name, full first name and middle initials
 
-%% environment for formatting the affiliations:
-\newenvironment{affiliations}{\begin{flushleft}\begin{enumerate}\setlength{\itemsep}{-0.5ex}\footnotesize\sffamily}{\end{enumerate}\end{flushleft}}
+%% Environment for formatting the affiliations:
+%% each affiliation is provided as an \item
+\newenvironment{affiliations}
+  {\begin{flushleft}\begin{enumerate}\setlength{\itemsep}{-0.5ex}\footnotesize\sffamily}
+  {\end{enumerate}\end{flushleft}}
 
-%% environment for formatting the abstract main text:
-\newenvironment{abstracttext}{\noindent\hspace*{-0.8ex}}{}
+%% Environment for formatting the abstract's main text:
+\newenvironment{abstracttext}
+  {\noindent\hspace*{-0.8ex}}
+  {}
 
-%% environment for formatting the figure block:
-\newenvironment{afigure}{\begin{center}\begin{minipage}{0.9\textwidth}}{\end{minipage}\end{center}}
-%% the maximum height of a figure:
+%% Environment for formatting the figure block:
+\newenvironment{afigure}
+  {\begin{center}\begin{minipage}{0.9\textwidth}}
+  {\end{minipage}\end{center}}
+  
+%% Maximum height of a figure:
 \newlength{\figureheight}
 \setlength{\figureheight}{0.35\textheight}
 
-%% environment for formatting the acknowledgements block:
-\newenvironment{acknowledgements}{\subsubsection{Acknowledgements}\small}{}
+%% Environment for formatting the acknowledgements block:
+\newenvironment{acknowledgements}
+  {\subsubsection{Acknowledgements}\small}
+  {}
 
-%% environment for formatting the references:
-\newenvironment{references}%
-  {\subsubsection{References}\footnotesize\begin{list}{}{\leftmargin=1.5em \listparindent=0pt \rightmargin=0pt \topsep=0.5ex \parskip=0pt \partopsep=0pt \itemsep=0pt \parsep=0pt}}%
+%% Environment for formatting the references:
+\newenvironment{references}
+  {\subsubsection{References}\footnotesize\begin{list}{}{\leftmargin=1.5em \listparindent=0pt \rightmargin=0pt \topsep=0.5ex \parskip=0pt \partopsep=0pt \itemsep=0pt \parsep=0pt}}
   {\end{list}}
 
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{document}
 
 \frontmatter
 
 %%%%%%%%%%%%%
 \mainmatter
-
 %endif
 
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 <%
 cur_state = check_cur_state(None, None)
 %>
@@ -210,7 +226,7 @@ cur_state = check_cur_state(None, None)
     new_chapter, new_section = check_cur_state(abstract, cur_state)
 %>
     %if new_chapter is not None:
-    \cleardoublepage \chapter{${new_chapter}} \addtocounter{chapterthumb}{1} \newpage
+    \cleardoublepage \chapter{${new_chapter}} \newpage
     %endif
     %if new_section is not None:
     \section{${new_section}}
@@ -218,12 +234,9 @@ cur_state = check_cur_state(None, None)
 
     ${mk_abstract(idx, abstract, figures is not None, show_meta)}
 % endfor
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% appendix
 %if not bare:
-\renewcommand{\headertext}{Index}
-\renewcommand{\headercolor}{white}
 \backmatter
 
 \printindex[authors]
@@ -234,7 +247,7 @@ cur_state = check_cur_state(None, None)
 
 <%def name="mk_abstract(idx, abstract, include_figures, print_meta)">
 \begin{abstractblock}
-\abstracttitle[Gwinner]{${abstract.poster_id}}{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title)}}
+\abstracttitle[]{${abstract.poster_id}}{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title)}}
 ${mk_authors(abstract.authors)}
 ${mk_affiliations(abstract.affiliations)}
 %if abstract.doi:
@@ -244,7 +257,6 @@ doi: \href{http://dx.doi.org/${abstract.doi}}{${abstract.doi}}
 \begin{abstracttext}
 ${abstract.text}
 \end{abstracttext}
-
 %if abstract.alt_id > 0 and abstract.conference is not None:
   \textbf{See also Poster}: ${abstract.conference.sort_id_to_string(abstract.alt_id)}
 %endif

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -100,9 +100,8 @@ import os
 
 \usepackage[breaklinks=true,colorlinks=true,citecolor=blue!30!black,urlcolor=blue!30!black,linkcolor=blue!30!black]{hyperref}
 
-\usepackage{multind}
-\makeindex{pages}
-\makeindex{posterid}
+\usepackage{imakeidx}
+\makeindex[name=authors, title={Author index}]
 
 %% environment for formatting the whole abstract:
 \newenvironment{abstractblock}{}{\newpage}
@@ -136,6 +135,8 @@ import os
 %%%%%%%%%%%%%
 \mainmatter
 
+\chapter{Etho 2020 --- Talks}
+
 %endif
 
 
@@ -166,10 +167,8 @@ cur_state = check_cur_state(None, None)
 %% appendix
 %if not bare:
 \backmatter
-\chapter{Index}
-\sffamily\footnotesize
-\chapter{Index}
-\printindex{pages}{Authors}
+
+\printindex[authors]
 
 \end{document}
 %endif
@@ -216,7 +215,7 @@ Talk: ${mk_tex_text(abstract.reason_for_talk)}\\*[-0.5ex]
      sep = ', ' if idx+1 < len(authors) else ''
      aff = author.format_affiliation()
      epi = '$^{%s}$' % aff if aff else ''
-  %> ${author.format_name()}${epi}${sep}\index{pages}{${author.index_name}}
+  %> ${author.format_name()}${epi}${sep}\index[authors]{${author.index_name}}
 % endfor
 \end{authors}
 </%def>

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -52,7 +52,6 @@ import os
 \usepackage{ucs}
 \usepackage[utf8x]{inputenc}
 \usepackage[LGR, T1]{fontenc}
-\usepackage[english]{babel}
 \usepackage{textcomp}
 \usepackage{textgreek}
 \usepackage{microtype}
@@ -62,6 +61,8 @@ import os
 \DeclareUnicodeCharacter{8288}{}
 \DeclareUnicodeCharacter{57404}{t}
 \DeclareUnicodeCharacter{700}{'}
+
+\usepackage[english]{babel}
 
 \usepackage{mathtools}
 \usepackage{amssymb}
@@ -84,7 +85,8 @@ import os
 \makeindex{pages}
 \makeindex{posterid}
 
-\newenvironment{abstractblock}{\newpage\noindent\begin{minipage}[t]{1.\textwidth}}{\end{minipage}\vspace{2ex}}
+\newenvironment{abstractblock}{\newpage\noindent\begin{minipage}[t]{1.\textwidth}}{\end{minipage}\vskip \glueexpr\smallskipamount + 0pt plus 10ex minus 3ex\relax
+    \pagebreak[3]}
 \newenvironment{authors}{}{}
 \newenvironment{affiliations}{\footnotesize\itshape\begin{enumerate}}{\end{enumerate}}
 \newenvironment{abstracttext}{}{}
@@ -94,6 +96,11 @@ import os
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{document}
+
+\frontmatter
+
+%%%%%%%%%%%%%
+\mainmatter
 
 %endif
 
@@ -109,7 +116,7 @@ cur_state = check_cur_state(None, None)
     new_chapter, new_section = check_cur_state(abstract, cur_state)
 %>
     %if new_chapter is not None:
-    %%\cleardoublepage \chapter{${new_chapter}} \addtocounter{chapterthumb}{1} \newpage
+    \cleardoublepage \chapter{${new_chapter}} \addtocounter{chapterthumb}{1} \newpage
     %endif
     %if new_section is not None:
     \section{${new_section}}
@@ -136,7 +143,7 @@ cur_state = check_cur_state(None, None)
 
 <%def name="mk_abstract(idx, abstract, include_figures, print_meta)">
 \begin{abstractblock}
-\section[${abstract.poster_id}]{${mk_tex_text(abstract.title)}}
+\subsection[${abstract.poster_id}]{${mk_tex_text(abstract.title)}}
 ${mk_authors(abstract.authors)}
 ${mk_affiliations(abstract.affiliations)}
 %if abstract.doi:
@@ -146,7 +153,9 @@ doi: \href{http://dx.doi.org/${abstract.doi}}{${abstract.doi}}
 \begin{abstracttext}
 ${abstract.text}
 \end{abstracttext}
-
+%if abstract.alt_id > 0 and abstract.conference is not None:
+  \textbf{See also Poster}: ${abstract.conference.sort_id_to_string(abstract.alt_id)}
+%endif
 %if len(abstract.figures) and include_figures:
     ${mk_figure(abstract.figures[0])}
 %endif

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -112,6 +112,9 @@ import os
 %% environment for formatting the affiliations:
 \newenvironment{affiliations}{\footnotesize\itshape\begin{enumerate}}{\end{enumerate}}
 
+%% environment for formatting the abstract main text:
+\newenvironment{abstracttext}{\noindent\hspace*{-0.8ex}}{}
+
 %% environment for formatting the figure block:
 \newenvironment{afigure}{\begin{center}\begin{minipage}{0.9\textwidth}}{\end{minipage}\end{center}}
 %% the maximum height of a figure:
@@ -135,7 +138,7 @@ import os
 %%%%%%%%%%%%%
 \mainmatter
 
-\chapter{Etho 2020 --- Talks}
+\chapter{Etho 2020 --- Poster}
 
 %endif
 
@@ -183,7 +186,9 @@ ${mk_affiliations(abstract.affiliations)}
 doi: \href{http://dx.doi.org/${abstract.doi}}{${abstract.doi}}
 %endif
 
+\begin{abstracttext}
 ${abstract.text}
+\end{abstracttext}
 
 %if abstract.alt_id > 0 and abstract.conference is not None:
   \textbf{See also Poster}: ${abstract.conference.sort_id_to_string(abstract.alt_id)}

--- a/gca/util.py
+++ b/gca/util.py
@@ -1,3 +1,4 @@
+from six import string_types
 
 
 class Selector(object):
@@ -71,3 +72,19 @@ def make_selector(string):
 def make_fields(field_str):
     fields = field_str.split('.')
     return map(make_selector, fields)
+
+
+s_from = u'aáàAâÂbBcCçÇdDeéEfFgGğĞhHiİîÎíīıIjJkKlLmMnNóoOöÖpPqQrRsSşŞtTuUûúÛüÜvVwWxXyYzZ'
+s_to   = u'aaaaaabbccccddeeeffgggghhiiiiiiiijjkkllmmnnoooooppqqrrssssttuuuuuuuvvwwxxyyzz'
+s_conv = dict(zip(s_from, s_to))
+
+
+def simplify_str(val):
+    """ Simplify (lowercase, no-utf8 characters) string values for comparisons.
+    """
+    if isinstance(val, string_types):
+        y = map(lambda x: s_conv[x] if x in s_conv else x, val)
+        return ''.join(y).strip()
+    else:
+        return val
+


### PR DESCRIPTION
The problem with the latex template in gca/tex.py is, that it is very specialized. I.e. one cannot simply edit the layout in the resulting latex file, because the layout is hardcoded in the body of the latex file. If somebody is fluent in latex but not in python/mako then it is hard to change the layout. The cool thing about latex is that you can have only information (the actual text and some logical formatting instructions) in the body and do the actual layout in the header (e.g. by means of the titlesec package for formatting the section titles, etc.

To achieve this goal I try to move all formatting instructions into the header. Each entity of an abstract is put into a newly defined environment so that the appearance can be changed by simply editing the definition of these environments in the header.

For now please leave the pull request open, because I will keep working on it. However, I would like to hear opinions on this.