### PR TITLE
Improved latex formatting

### DIFF
--- a/gca/core.py
+++ b/gca/core.py
@@ -176,6 +176,14 @@ class Affiliation(Entity):
         active = filter(bool, components)
         return u', '.join(active)
 
+    def latex_format_affiliation(self):
+        department = self._data['department']
+        section = self._data['section']
+        address = self._data['address']
+        country = self._data['country']
+        components = [u', ' + c if c and len(c) else u'' for c in [department, section, address, country]]
+        return u'\\affiliation{' + '}{'.join(components) + '}'
+
 
 class Author(Entity):
     def __init__(self, data=None):
@@ -234,14 +242,20 @@ class Author(Entity):
         first = ''
         shortfirst = ''
         if d['firstName'] and len(d['firstName']):
-            first = d['firstName']
-            shortfirst = self.format_initials(d['firstName'], suffix='.')
+            first = d['firstName'].strip()
+            shortfirst = self.format_initials(d['firstName'],
+                                              separator=' ', suffix='.')
         middle = ''
         shortmiddle = ''
         if d['middleName'] and len(d['middleName']):
-            middle = u' ' + d['middleName']
-            shortmiddle = u' ' + self.format_initials(d['middleName'], suffix='.')
-        return u"\\authorname{%s}{%s}{%s}{%s}{%s}" % (first, middle, shortfirst, shortmiddle, d['lastName'])
+            middle = d['middleName'].strip()
+            if len(middle) == 1:
+                middle += '.'
+            middle = u' ' + middle
+            shortmiddle = u' ' + self.format_initials(d['middleName'],
+                                                      separator=' ',
+                                                      suffix='.')
+        return u"\\authorname{%s}{%s}{%s}{%s}{%s}" % (first, middle, shortfirst, shortmiddle, d['lastName'].strip())
 
     def format_affiliation(self):
         af = self._data['affiliations']
@@ -258,8 +272,8 @@ class Author(Entity):
     def format_initials(name, separator='', suffix=''):
         if not name:
             return ""
-        comps = name.split(' ')
-        return separator.join([a[0] + suffix for a in comps])
+        comps = [a.strip('.').split('.') for a in name.strip().split(' ')]
+        return separator.join([b[0] + suffix for a in comps for b in a])
 
 
 class Reference(Entity):

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -154,29 +154,28 @@ import os
 %endif
 
 %% Command for setting the abstract's title. It gets four arguments:
-%% 1. some optional string (user supplied by manual editing the latex file)
-%% 2. poster ID
-%% 3. last name of first author
-%% 4. title of abstract
-\newcommand{\abstracttitle}[4][]{\section[#3: #4]{#4}}
-%%\newcommand{\abstracttitle}[4][]{\section[#2]{#4}}
+%% 1. poster ID
+%% 2. last name of first author
+%% 3. title of abstract
+\newcommand{\abstracttitle}[3]{\section[#2: #3]{#3}}
+%%\newcommand{\abstracttitle}[3]{\section[#1]{#3}}
 
 %% Environment for formatting the authors block:
 \newenvironment{authors}
   {\begin{flushleft}\setstretch{1.2}\sffamily}
   {\end{flushleft}\vspace{-3ex}}
 
-%% Command for formatting of author names. Five arguments:
+%% Command for formatting author names. Five arguments:
 %% 1. first name
 %% 2. middle name
-%% 3. initial of first name
-%% 4. initial of middle name
+%% 3. initials of first name
+%% 4. initials of middle name
 %% 5. last name
-\newcommand{\authorname}[5]{\mbox{#1#2 \textbf{#5}}}  %% first and middle name plus bold last name
+\newcommand{\authorname}[5]{\mbox{#1#2 \textbf{#5}}}  %% full first and middle name plus bold last name
 %% \newcommand{\authorname}[5]{\mbox{\textbf{#5}, #3#4}}  %% bold last name, first and middle initials
 %% \newcommand{\authorname}[5]{\mbox{\textbf{#5}, #1#4}}  %% bold last name, full first name and middle initials
 
-%% Environment for formatting the affiliations:
+%% Environment for formatting affiliations:
 %% each affiliation is provided as an \item
 \newenvironment{affiliations}
   {\begin{flushleft}\begin{enumerate}\setlength{\itemsep}{-0.5ex}\footnotesize\sffamily}
@@ -204,6 +203,10 @@ import os
 %% Maximum height of a figure:
 \newlength{\figureheight}
 \setlength{\figureheight}{0.3\textheight}
+
+%% Command for including an image:
+\newcommand{\includeimage}[1]
+  {\centerline{\includegraphics[width=1\linewidth, height=1\figureheight, keepaspectratio]{#1}}}
 
 %% Environment for formatting the acknowledgements block:
 \newenvironment{acknowledgements}
@@ -256,7 +259,7 @@ cur_state = check_cur_state(None, None)
 
 <%def name="mk_abstract(idx, abstract, include_figures, print_meta)">
 \begin{abstractblock}
-\abstracttitle[]{${abstract.poster_id}}{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title).rstrip('.')}}
+\abstracttitle{${abstract.poster_id}}{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title).rstrip('.')}}
 ${mk_authors(abstract.authors)}
 ${mk_affiliations(abstract.affiliations)}
 %if abstract.doi:
@@ -327,7 +330,7 @@ ${mk_tex_text(acknowledgements)}
 
 <%def name="mk_figure(figure)">
 \begin{afigure}
-    \centerline{\includegraphics[width=1\linewidth, height=1\figureheight, keepaspectratio]{${figure.uuid}}}
+    \includeimage{${figure.uuid}}
     \captionof*{figure}{\small ${mk_tex_text(figure.caption)}}
 \end{afigure}
 </%def>

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -203,7 +203,7 @@ import os
   
 %% Maximum height of a figure:
 \newlength{\figureheight}
-\setlength{\figureheight}{0.35\textheight}
+\setlength{\figureheight}{0.3\textheight}
 
 %% Environment for formatting the acknowledgements block:
 \newenvironment{acknowledgements}
@@ -256,7 +256,7 @@ cur_state = check_cur_state(None, None)
 
 <%def name="mk_abstract(idx, abstract, include_figures, print_meta)">
 \begin{abstractblock}
-\abstracttitle[]{${abstract.poster_id}}{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title)}}
+\abstracttitle[]{${abstract.poster_id}}{${abstract.authors[0].last_name}}{${mk_tex_text(abstract.title).rstrip('.')}}
 ${mk_authors(abstract.authors)}
 ${mk_affiliations(abstract.affiliations)}
 %if abstract.doi:

--- a/gca/tex.py
+++ b/gca/tex.py
@@ -182,6 +182,15 @@ import os
   {\begin{flushleft}\begin{enumerate}\setlength{\itemsep}{-0.5ex}\footnotesize\sffamily}
   {\end{enumerate}\end{flushleft}}
 
+\usepackage{xstring}
+%% Command for formatting each affiliation. Four arguments:
+%% 1. department
+%% 2. section
+%% 3. address
+%% 4. country
+%% Each of the arguments are either empty strings or preceded by ', '.
+\newcommand{\affiliation}[4]{\StrGobbleLeft{#1#2#3#4}{2}}
+
 %% Environment for formatting the abstract's main text:
 \newenvironment{abstracttext}
   {\noindent\hspace*{-0.8ex}}
@@ -234,9 +243,9 @@ cur_state = check_cur_state(None, None)
 
     ${mk_abstract(idx, abstract, figures is not None, show_meta)}
 % endfor
+%if not bare:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% appendix
-%if not bare:
 \backmatter
 
 \printindex[authors]
@@ -297,7 +306,7 @@ Talk: ${mk_tex_text(abstract.reason_for_talk)}\\*[-0.5ex]
 <%def name="mk_affiliations(affiliations)">
 \begin{affiliations}
 % for idx, affiliation in enumerate(affiliations):
-  \item[${idx+1}.] ${mk_tex_text(affiliation.format_affiliation())}
+  \item[${idx+1}.] ${mk_tex_text(affiliation.latex_format_affiliation())}
 % endfor
 \end{affiliations}
 </%def>


### PR DESCRIPTION
So, here come some final fixes:

- improved formatting of first and middle Names. 
  There were problems with names given as 'H.J.' or 'MS', as well as with 'Hans-Juergen'.
  Run 
  ```
 python3 -m gca.core
  ```
 to see this at work. Ideally you move this test code in `main` to some test script...

- Abstract titles in the latex file get a final full stop stripped

- Added latex command for including a figure.
